### PR TITLE
A handful of modifications to allow installation on a windows machine.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby "2.1.1"
+ruby "1.9.3"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.0'
@@ -84,3 +84,6 @@ gem 'rubocop'
 # gem 'capistrano', group: :development
 
 gem 'devise'
+
+# required for windows installations
+gem 'tzinfo-data'

--- a/README.md
+++ b/README.md
@@ -17,14 +17,15 @@ start (or please link to a better tutorial in this readme once you find
 one :)
 http://guides.rubyonrails.org/getting_started.html
 
-You must install Postgres (http://postgresapp.com/)
+You must install Postgres (http://postgresapp.com/ for MAC, 
+http://www.postgresql.org/download/ for others)
 and set your PATH in your ~/.bashrc  For example:
 
 	export PATH="/Applications/Postgres93.app/Contents/MacOS/bin:$PATH"
 
 and also create a user for the BZ application:
 
-    createuser -s beyondz-playground
+    createuser -s beyondzplayground
 
 After your environment is setup, fork this repository on Github. Then in the location you want the local copy, run:
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,7 +7,10 @@ class Task < ActiveRecord::Base
   has_many :responses, class_name: 'TaskResponse', dependent: :destroy
   has_many :comments, dependent: :destroy
 
-  scope :for_assignment, -> (assignment_id) {
+  # Found syntax error here.  Because I'm a Ruby noob, I'm leaving this comment
+  # in case my "fix" actually changed the semantics.
+  # scope :for_assignment, -> (assignment_id) {
+  scope :for_assignment, -> assignment_id {
     where(assignment_id: assignment_id)
   }
   scope :submitted, -> { where.not(state: :new) }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 # This file should contain all the record creation needed to seed the database
 # with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db

--- a/env.sample
+++ b/env.sample
@@ -11,7 +11,7 @@
 RAILS_SECRET_TOKEN=6e5fae17104f20e1f74398b51229a323873ee434b8d7cabe08cce9b28d5707fd1f49f3cfcd9b28ea2ba0b2c3babdb1e552678435a05eb148b499cac08cebf7d0
 
 # database connection credentials
-DATABASE_USERNAME=beyondz-playground
+DATABASE_USERNAME=beyondzplayground
 DATABASE_PASSWORD=
 
 # the credentials to connect to the outgoing SMTP server for sending emails


### PR DESCRIPTION
A running monologue of my installation progress, which explains the motivation for each change:

The first problem was with `rake db:create`.  It failed with the message `password authentication failed for user "beyondz-playground"`.  Eventually I got the idea that it might not like the dash in the username, so I made another user without it, adjusted .evn & such, and the command worked.

Next, `db:migrate` didn't work, with the message `No source of timezone data could be found`.  I had to include tzinfo-data in the gemfile to fix this.

Next, `db:seed didn't work` (and I began sensing a pattern).  The error: `invalid byte sequence in US-ASCII (Argument Error)`.  I wrote a quick program to scan the project for files with non-ascii characters, and found the offender to be db/seeds.rb.  I added `#encoding: utf-8` to the top of that file to get past the error.

However, that only get me to the next error with `db:seed`.  This time it was a syntax error in app/models/task.rb.  I (maybe?) fixed that, and moved on.
